### PR TITLE
Add Flask web app and Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install Flask
+ENV FLASK_APP=web_app.py
+CMD ["flask", "run", "--host=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # mass-block-x-users
-mass block a list of x-users 
+
+mass block a list of x-users
+
+## Web application
+
+A simple Flask app provides a form to upload a list of usernames along with a
+`source_id` and `token`. On submission it calls `block_from_file` and displays
+the result for each user.
+
+### Run with Flask
+
+```bash
+pip install flask
+export FLASK_APP=web_app.py
+flask run
+```
+
+The application will be available at http://localhost:5000/
+
+### Docker
+
+```bash
+docker build -t mass-block-x-users .
+docker run -p 5000:5000 mass-block-x-users
+```
+
+The container exposes the app on port 5000.

--- a/block.py
+++ b/block.py
@@ -1,0 +1,18 @@
+from typing import Dict, Iterable
+
+def block_from_file(file_obj: Iterable[str], source_id: str, token: str) -> Dict[str, str]:
+    """Block users listed in ``file_obj``.
+
+    This stub function reads each line from the provided file-like object and
+    returns a mapping of username to a message indicating the user was blocked.
+    In a real implementation this would call the X API using ``source_id`` and
+    ``token``.
+    """
+    results: Dict[str, str] = {}
+    for line in file_obj:
+        username = line.strip()
+        if not username:
+            continue
+        # Placeholder: real blocking logic would go here
+        results[username] = "blocked"
+    return results

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,44 @@
+from flask import Flask, request, render_template_string
+from block import block_from_file
+
+app = Flask(__name__)
+
+FORM_TEMPLATE = """
+<!doctype html>
+<title>Mass Block X Users</title>
+<h1>Upload user list</h1>
+<form method="post" enctype="multipart/form-data">
+  <label>Username file: <input type="file" name="userfile" required></label><br>
+  <label>Source ID: <input type="text" name="source_id" required></label><br>
+  <label>Token: <input type="password" name="token" required></label><br>
+  <input type="submit" value="Block">
+</form>
+"""
+
+RESULT_TEMPLATE = """
+<!doctype html>
+<title>Block Results</title>
+<h1>Block Results</h1>
+<ul>
+  {% for user, status in results.items() %}
+    <li>{{ user }}: {{ status }}</li>
+  {% endfor %}
+</ul>
+<a href="{{ url_for('index') }}">Back</a>
+"""
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        uploaded = request.files.get('userfile')
+        source_id = request.form.get('source_id', '')
+        token = request.form.get('token', '')
+        if not uploaded:
+            return "No file uploaded", 400
+        results = block_from_file(uploaded.stream, source_id, token)
+        return render_template_string(RESULT_TEMPLATE, results=results)
+    return render_template_string(FORM_TEMPLATE)
+
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
## Summary
- add stub `block_from_file` for per-user blocking results
- create Flask `web_app.py` with upload form and results display
- document usage and provide Dockerfile for containerized runs

## Testing
- `python -m py_compile block.py web_app.py`
- `python - <<'PY'
import web_app
print('loaded app', web_app.app.name)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b5ab3047948332a3a9488219140421