### PR TITLE
Handle bytes input in block function and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mass-block-x-users
 
-mass block a list of x-users
+Mass block a list of X users.
 
 ## Web application
 
@@ -11,12 +11,20 @@ the result for each user.
 ### Run with Flask
 
 ```bash
-pip install flask
+pip install -r requirements.txt
 export FLASK_APP=web_app.py
 flask run
 ```
 
 The application will be available at http://localhost:5000/
+
+### Tests
+
+Run the unit tests with:
+
+```bash
+pytest
+```
 
 ### Docker
 

--- a/block.py
+++ b/block.py
@@ -1,15 +1,21 @@
 from typing import Dict, Iterable
 
-def block_from_file(file_obj: Iterable[str], source_id: str, token: str) -> Dict[str, str]:
+
+def block_from_file(
+    file_obj: Iterable[str], source_id: str, token: str
+) -> Dict[str, str]:
     """Block users listed in ``file_obj``.
 
     This stub function reads each line from the provided file-like object and
     returns a mapping of username to a message indicating the user was blocked.
-    In a real implementation this would call the X API using ``source_id`` and
-    ``token``.
+    The ``file_obj`` may yield either strings or bytes; bytes are decoded using
+    UTF-8. In a real implementation this would call the X API using
+    ``source_id`` and ``token``.
     """
     results: Dict[str, str] = {}
     for line in file_obj:
+        if isinstance(line, bytes):
+            line = line.decode("utf-8")
         username = line.strip()
         if not username:
             continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+pytest

--- a/test_block.py
+++ b/test_block.py
@@ -1,0 +1,12 @@
+import io
+from block import block_from_file
+
+def test_block_from_text_stream():
+    file_obj = io.StringIO("alice\nbob\n")
+    result = block_from_file(file_obj, "id", "token")
+    assert result == {"alice": "blocked", "bob": "blocked"}
+
+def test_block_from_binary_stream():
+    file_obj = io.BytesIO(b"alice\nbob\n")
+    result = block_from_file(file_obj, "id", "token")
+    assert result == {"alice": "blocked", "bob": "blocked"}


### PR DESCRIPTION
## Summary
- decode byte lines in `block_from_file` so uploaded files render correctly
- document dependencies and add unit tests for text and binary streams
- ignore build artifacts with a new `.gitignore`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ad4f2e008332902f254ade0ee634