### PR TITLE
fix: use correct API host for block requests

### DIFF
--- a/block.py
+++ b/block.py
@@ -323,13 +323,13 @@ def block_from_file(
     -----
     The real X API requires many headers and cookies.  This function performs a
     minimal request using ``requests`` so that it can be easily mocked during
-    tests.  It posts to ``https://api.x.com/1.1/blocks/create.json`` for each
-    username.  Any network or HTTP errors are captured and returned in the
+    tests.  It posts to ``https://api.twitter.com/1.1/blocks/create.json`` for
+    each username.  Any network or HTTP errors are captured and returned in the
     results mapping.
     """
 
     results: Dict[str, str] = {}
-    url = "https://api.x.com/1.1/blocks/create.json"
+    url = "https://api.twitter.com/1.1/blocks/create.json"
     headers = {"User-Agent": "mass-block-x-users"}
     cookies = {"auth_token": token}
 

--- a/test_block.py
+++ b/test_block.py
@@ -46,7 +46,7 @@ def test_block_from_text_stream(monkeypatch):
     assert result == {"alice": "blocked", "bob": "blocked"}
     assert len(calls) == 2
     for call in calls:
-        assert call["url"] == "https://api.x.com/1.1/blocks/create.json"
+        assert call["url"] == "https://api.twitter.com/1.1/blocks/create.json"
         assert call["cookies"] == {"auth_token": "token"}
         assert call["json"]["source_id"] == "id"
         assert call["json"]["screen_name"] in {"alice", "bob"}


### PR DESCRIPTION
## Summary
- point block requests to Twitter v1.1 endpoint
- update tests to expect new URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d91867488332a9d5e1070a952083