### PR TITLE
Add bearer and CSRF headers for blocking requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,23 @@ The server will start on http://localhost:5000/.
 ### 4. Use the app
 
 In your browser visit http://localhost:5000/.
-Upload a text file with one username per line and enter your `source_id` and `token` from X. Submit the form to block each user and review the results.
+Upload a text file with one username per line and enter your `source_id`, `token`, `ct0`, and `bearer_token` from X. Submit the form to block each user and review the results.
 
-You can alternatively set the `SOURCE_ID` and `AUTH_TOKEN` environment variables before launching the app and leave the fields blank in the form.
+You can alternatively set the `SOURCE_ID`, `AUTH_TOKEN`, `CT0`, and `BEARER_TOKEN` environment variables before launching the app and leave the fields blank in the form.
 
-#### Finding your `source_id` and `token`
+#### Finding your `source_id`, `token`, `ct0`, and `bearer_token`
 
-These two pieces of information tell X which account is doing the blocking.
+These pieces of information tell X which account is doing the blocking and authorize the requests.
 
 - **source_id** – This is your numeric X user ID. To find it, visit <https://x.com/settings/your_twitter_data> and look for **User ID** in the *Account* section, or use <https://get-id-x.foundtt.com/en/> to look it up.
 - **token** – This is the `auth_token` cookie from your browser. With X open in your browser:
   1. Press <kbd>F12</kbd> to open the developer tools.
   2. Go to the **Application** (or **Storage**) tab and open the **Cookies** entry for `https://x.com`.
   3. Find the cookie named `auth_token` and copy its value.
+- **ct0** – Another cookie found alongside `auth_token`. Copy the value of the `ct0` cookie from the same list.
+- **bearer_token** – Inspect any network request on X in the **Network** tab and copy the value from the `Authorization: Bearer` header.
 
-Keep this token secret; anyone with it can act on your X account.
+Keep these tokens secret; anyone with them can act on your X account.
 
 The home page also links to **Block SOL Shills**, which blocks a predefined set of usernames without uploading a file.
 

--- a/test_block.py
+++ b/test_block.py
@@ -22,11 +22,11 @@ class DummyResponse:
 def make_fake_post(collected: List[Dict]):
     """Return a ``requests.post`` replacement that records calls."""
 
-    def fake_post(url, json=None, headers=None, cookies=None, timeout=None):
+    def fake_post(url, data=None, headers=None, cookies=None, timeout=None):
         collected.append(
             {
                 "url": url,
-                "json": json,
+                "data": data,
                 "headers": headers,
                 "cookies": cookies,
                 "timeout": timeout,
@@ -43,16 +43,25 @@ def test_block_from_text_stream(monkeypatch):
 
 
     file_obj = io.StringIO("alice\nbob\n")
-    result = block.block_from_file(file_obj, "id", "token")
+    result = block.block_from_file(
+        file_obj,
+        "id",
+        "token",
+        ct0="csrf",
+        bearer_token="bearer",
+    )
 
     assert result == {"alice": "blocked", "bob": "blocked"}
 
     assert len(calls) == 2
     for call in calls:
         assert call["url"] == "https://api.twitter.com/1.1/blocks/create.json"
-        assert call["cookies"] == {"auth_token": "token"}
-        assert call["json"]["source_id"] == "id"
-        assert call["json"]["screen_name"] in {"alice", "bob"}
+        assert call["cookies"] == {"auth_token": "token", "ct0": "csrf"}
+        assert call["headers"]["Authorization"] == "Bearer bearer"
+        assert call["headers"]["X-Csrf-Token"] == "csrf"
+        assert call["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+        assert call["data"]["source_id"] == "id"
+        assert call["data"]["screen_name"] in {"alice", "bob"}
 
 
 def test_block_from_binary_stream(monkeypatch):
@@ -61,58 +70,86 @@ def test_block_from_binary_stream(monkeypatch):
 
 
     file_obj = io.BytesIO(b"alice\nbob\n")
-    result = block.block_from_file(file_obj, "id", "token")
+    result = block.block_from_file(
+        file_obj,
+        "id",
+        "token",
+        ct0="csrf",
+        bearer_token="bearer",
+    )
 
     assert result == {"alice": "blocked", "bob": "blocked"}
     assert len(calls) == 2
     for call in calls:
-        assert call["json"]["screen_name"] in {"alice", "bob"}
+        assert call["data"]["screen_name"] in {"alice", "bob"}
 
 
 def test_block_sol_shills(monkeypatch):
     calls: List[Dict] = []
     monkeypatch.setattr(block.requests, "post", make_fake_post(calls))
 
-    result = block.block_sol_shills("id", "token")
+    result = block.block_sol_shills("id", "token", ct0="csrf", bearer_token="bearer")
 
     assert set(result.keys()) == set(block.SOL_SHILLS)
     assert all(status == "blocked" for status in result.values())
     assert len(calls) == len(block.SOL_SHILLS)
     # Ensure usernames sent to the API are normalized without the '@' prefix.
-    sent_usernames = {call["json"]["screen_name"] for call in calls}
+    sent_usernames = {call["data"]["screen_name"] for call in calls}
     assert sent_usernames == {name.lstrip("@") for name in block.SOL_SHILLS}
 
 
 def test_auth_error(monkeypatch):
-    def fake_post(url, json=None, headers=None, cookies=None, timeout=None):
+    def fake_post(url, data=None, headers=None, cookies=None, timeout=None):
         return DummyResponse(401)
 
     monkeypatch.setattr(block.requests, "post", fake_post)
     file_obj = io.StringIO("alice\n")
-    result = block.block_from_file(file_obj, "id", "token")
+    result = block.block_from_file(
+        file_obj,
+        "id",
+        "token",
+        ct0="csrf",
+        bearer_token="bearer",
+    )
     assert result == {"alice": "unauthorized"}
 
 
 def test_rate_limit_retry(monkeypatch):
     responses = [DummyResponse(429), DummyResponse(200)]
 
-    def fake_post(url, json=None, headers=None, cookies=None, timeout=None):
+    def fake_post(url, data=None, headers=None, cookies=None, timeout=None):
         return responses.pop(0)
 
     monkeypatch.setattr(block.requests, "post", fake_post)
     monkeypatch.setattr(block.time, "sleep", lambda s: None)
     file_obj = io.StringIO("alice\n")
-    result = block.block_from_file(file_obj, "id", "token", max_retries=2, backoff=0)
+    result = block.block_from_file(
+        file_obj,
+        "id",
+        "token",
+        ct0="csrf",
+        bearer_token="bearer",
+        max_retries=2,
+        backoff=0,
+    )
     assert result == {"alice": "blocked"}
 
 
 def test_rate_limit_gives_up(monkeypatch):
-    def fake_post(url, json=None, headers=None, cookies=None, timeout=None):
+    def fake_post(url, data=None, headers=None, cookies=None, timeout=None):
         return DummyResponse(429)
 
     monkeypatch.setattr(block.requests, "post", fake_post)
     monkeypatch.setattr(block.time, "sleep", lambda s: None)
     file_obj = io.StringIO("alice\n")
-    result = block.block_from_file(file_obj, "id", "token", max_retries=2, backoff=0)
+    result = block.block_from_file(
+        file_obj,
+        "id",
+        "token",
+        ct0="csrf",
+        bearer_token="bearer",
+        max_retries=2,
+        backoff=0,
+    )
     assert result == {"alice": "rate limited"}
 

--- a/web_app.py
+++ b/web_app.py
@@ -12,6 +12,8 @@ FORM_TEMPLATE = """
   <label>Username file: <input type="file" name="userfile" required></label><br>
   <label>Source ID: <input type="text" name="source_id"></label><br>
   <label>Token: <input type="password" name="token"></label><br>
+  <label>ct0: <input type="text" name="ct0"></label><br>
+  <label>Bearer Token: <input type="password" name="bearer_token"></label><br>
   <input type="submit" value="Block">
 </form>
 <p>Or <a href="{{ url_for('block_sol_shills_route') }}">Block SOL Shills</a></p>
@@ -35,9 +37,17 @@ def index():
         uploaded = request.files.get('userfile')
         source_id = request.form.get('source_id') or os.getenv('SOURCE_ID', '')
         token = request.form.get('token') or os.getenv('AUTH_TOKEN', '')
+        ct0 = request.form.get('ct0') or os.getenv('CT0', '')
+        bearer_token = request.form.get('bearer_token') or os.getenv('BEARER_TOKEN', '')
         if not uploaded:
             return "No file uploaded", 400
-        results = block_from_file(uploaded.stream, source_id, token)
+        results = block_from_file(
+            uploaded.stream,
+            source_id,
+            token,
+            ct0=ct0,
+            bearer_token=bearer_token,
+        )
         return render_template_string(RESULT_TEMPLATE, results=results)
     return render_template_string(FORM_TEMPLATE)
 
@@ -49,6 +59,8 @@ SOL_SHILLS_TEMPLATE = """
 <form method="post">
   <label>Source ID: <input type="text" name="source_id"></label><br>
   <label>Token: <input type="password" name="token"></label><br>
+  <label>ct0: <input type="text" name="ct0"></label><br>
+  <label>Bearer Token: <input type="password" name="bearer_token"></label><br>
   <input type="submit" value="Block SOL Shills">
 </form>
 """
@@ -59,7 +71,14 @@ def block_sol_shills_route():
     if request.method == 'POST':
         source_id = request.form.get('source_id') or os.getenv('SOURCE_ID', '')
         token = request.form.get('token') or os.getenv('AUTH_TOKEN', '')
-        results = block_sol_shills(source_id, token)
+        ct0 = request.form.get('ct0') or os.getenv('CT0', '')
+        bearer_token = request.form.get('bearer_token') or os.getenv('BEARER_TOKEN', '')
+        results = block_sol_shills(
+            source_id,
+            token,
+            ct0=ct0,
+            bearer_token=bearer_token,
+        )
         return render_template_string(RESULT_TEMPLATE, results=results)
     return render_template_string(SOL_SHILLS_TEMPLATE)
 


### PR DESCRIPTION
## Summary
- support ct0 cookie and OAuth2 bearer token in blocking requests
- send block requests as form data with required headers
- document new authentication values and expose them in the web UI and API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4b9c3308332851869ed75068097