### PR TITLE
Handle SOL shill blocks in background tasks

### DIFF
--- a/test_web_app.py
+++ b/test_web_app.py
@@ -1,0 +1,39 @@
+import re
+import time
+from unittest.mock import patch
+
+import pytest
+
+import web_app
+
+
+@pytest.fixture
+def client():
+    web_app.app.config['TESTING'] = True
+    with web_app.app.test_client() as client:
+        yield client
+
+
+def test_block_sol_shills_background(client):
+    fake_users = ['user1', 'user2']
+
+    def fake_block(file_obj, source_id, token):
+        username = next(iter(file_obj))
+        return {username: 'blocked'}
+
+    with patch.object(web_app, 'SOL_SHILLS', fake_users), \
+         patch.object(web_app, 'block_from_file', side_effect=fake_block):
+        resp = client.post('/block-sol-shills', data={'source_id': '1', 'token': 't'})
+        assert resp.status_code == 200
+        match = re.search(r'Task ID: ([\w-]+)', resp.data.decode())
+        assert match
+        task_id = match.group(1)
+        status_url = f'/tasks/{task_id}'
+        for _ in range(20):
+            status_resp = client.get(status_url)
+            data = status_resp.get_json()
+            if data['status'] == 'finished':
+                break
+            time.sleep(0.1)
+        assert data['status'] == 'finished'
+        assert data['result'] == {u: 'blocked' for u in fake_users}

--- a/web_app.py
+++ b/web_app.py
@@ -1,8 +1,27 @@
-from flask import Flask, request, render_template_string
-from block import block_from_file, block_sol_shills
+from flask import Flask, request, render_template_string, url_for, jsonify
+from block import block_from_file, SOL_SHILLS
 import os
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, Optional
 
 app = Flask(__name__)
+
+@dataclass
+class Task:
+    """Simple structure to track background task state."""
+
+    status: str = "pending"
+    progress: Dict[str, int] = field(
+        default_factory=lambda: {"current": 0, "total": 0}
+    )
+    result: Optional[Dict[str, str]] = None
+
+
+# In-memory task tracking
+tasks: Dict[str, Task] = {}
+tasks_lock = threading.Lock()
 
 FORM_TEMPLATE = """
 <!doctype html>
@@ -53,15 +72,75 @@ SOL_SHILLS_TEMPLATE = """
 </form>
 """
 
+TASK_TEMPLATE = """
+<!doctype html>
+<title>Task Submitted</title>
+<h1>Task Submitted</h1>
+<p>Task ID: {{ task_id }}</p>
+<p>Check <a href="{{ status_url }}">task status</a>.</p>
+<a href="{{ url_for('index') }}">Back</a>
+"""
+
+
+def _block_sol_shills_task(task_id: str, source_id: str, token: str) -> None:
+    """Background worker to block SOL shills."""
+    app.logger.info("Task %s started", task_id)
+    total = len(SOL_SHILLS)
+    results: dict[str, str] = {}
+    with tasks_lock:
+        task = tasks[task_id]
+        task.status = "running"
+        task.progress = {"current": 0, "total": total}
+    for idx, username in enumerate(SOL_SHILLS, start=1):
+        partial = block_from_file([username], source_id, token)
+        results.update(partial)
+        with tasks_lock:
+            tasks[task_id].progress = {"current": idx, "total": total}
+        app.logger.info(
+            "Task %s progress: %s/%s", task_id, idx, total
+        )
+    with tasks_lock:
+        task = tasks[task_id]
+        task.status = "finished"
+        task.result = results
+    app.logger.info("Task %s finished", task_id)
+
 
 @app.route('/block-sol-shills', methods=['GET', 'POST'])
 def block_sol_shills_route():
     if request.method == 'POST':
         source_id = request.form.get('source_id') or os.getenv('SOURCE_ID', '')
         token = request.form.get('token') or os.getenv('AUTH_TOKEN', '')
-        results = block_sol_shills(source_id, token)
-        return render_template_string(RESULT_TEMPLATE, results=results)
+        task_id = str(uuid.uuid4())
+        with tasks_lock:
+            tasks[task_id] = Task()
+        app.logger.info("Scheduling task %s to block SOL shills", task_id)
+        thread = threading.Thread(
+            target=_block_sol_shills_task, args=(task_id, source_id, token), daemon=True
+        )
+        thread.start()
+        status_url = url_for('task_status', task_id=task_id, _external=True)
+        return render_template_string(
+            TASK_TEMPLATE, task_id=task_id, status_url=status_url
+        )
     return render_template_string(SOL_SHILLS_TEMPLATE)
+
+
+@app.route('/tasks/<task_id>')
+def task_status(task_id: str):
+    with tasks_lock:
+        task = tasks.get(task_id)
+    if not task:
+        return jsonify({"error": "task not found"}), 404
+    if task.status == "finished":
+        return jsonify(
+            {
+                "status": task.status,
+                "progress": task.progress,
+                "result": task.result,
+            }
+        )
+    return jsonify({"status": task.status, "progress": task.progress})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Execute SOL shill blocking in a background thread
- Track task state with a dataclass and provide a polling endpoint
- Test background task scheduling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4d6066083329bf6a5caa631b586